### PR TITLE
chore/default-api-link

### DIFF
--- a/quasar.config.js
+++ b/quasar.config.js
@@ -67,6 +67,9 @@ module.exports = configure(function (ctx) {
       env: {
         ...env,
         APP_VERSION: pkg.version,
+        API_BASE_URL: ctx.dev
+          ? 'https://api.staging.mycure.md'
+          : 'https://api.mycure.md',
       },
       // rawDefine: {}
       // ignorePublicFolder: true,


### PR DESCRIPTION
This PR adds the `API_BASE_URL` environment variable to the Quasar configuration file. This allows the application to use different API endpoints depending on the environment. In development, the application will use the staging API endpoint, while in production, it will use the production API endpoint. This change makes it easier to manage and switch between different environments.